### PR TITLE
feat(*): 引数無しのCONNECT文に対応

### DIFF
--- a/dblib/ocesql.c
+++ b/dblib/ocesql.c
@@ -195,6 +195,89 @@ OCESQLIDConnect(struct sqlca_t *st, char *atdb, int atdblen, char *user, int use
 	return 0;
 }
 
+/*
+ * <Function name>
+ *   OCESQLConnectShort
+ *
+ * <Outline>
+ *   データベース接続を試みる。成功したらコネクションIDを発行して返す
+ *   return する前に st.sqlcode に値をセットすること。
+ *
+ * <Input>
+ *   @st: SQLCA pointer
+ *   //@name: database name
+ *   //@user: user name
+ *   //@passwd: password
+ *
+ * <Output>
+ *   success : ConnectionId
+ *   failure ; OCESQL_NO_CONNECTION
+ */
+int
+OCESQLConnectShort(struct sqlca_t *st){
+	char	user[256];
+	int		userlen;
+	char	passwd[256];
+	int		passwdlen;
+	char	name[256];
+	int		namelen;
+
+	LOG("OCESQLConnectShort start\n");
+	(void)memset(user, 0x00, sizeof(user));
+	userlen = 0;
+	(void)memset(passwd, 0x00, sizeof(passwd));
+	passwdlen = 0;
+	(void)memset(name, 0x00, sizeof(name));
+	namelen = 0;
+	return _ocesqlConnect(st, user, userlen, passwd, passwdlen, name, namelen, NULL);
+}
+
+/*
+ * <Function name>
+ *   OCESQLIDConnectShort
+ *
+ * <Outline>
+ *   データベース接続を試みる。成功したらコネクションIDを発行して返す
+ *   return する前に st.sqlcode に値をセットすること。
+ *
+ * <Input>
+ *   @st: SQLCA pointer
+ *   @atdb: Connection Identifier
+ *   @atdblen: length of atdb
+ *   //@name: database name
+ *   //@user: user name
+ *   //@passwd: password
+ *
+ * <Output>
+ *   success : ConnectionId
+ *   failure ; OCESQL_NO_CONNECTION
+ */
+int
+OCESQLIDConnectShort(struct sqlca_t *st, char *atdb, int atdblen){
+	char *atdbbuf;
+	LOG("OCESQLIDConnect start\n");
+	atdbbuf = get_str_without_after_space(oc_strndup(atdb, atdblen));
+	if((!atdbbuf) || (*atdbbuf == '\0')){
+		OCDBSetLibErrorStatus(st,OCPG_VAR_NOT_CHAR);
+		return 1;
+	}
+	char	user[256];
+	int		userlen;
+	char	passwd[256];
+	int		passwdlen;
+	char	name[256];
+	int		namelen;
+
+	LOG("OCESQLConnectShort start\n");
+	(void)memset(user, 0x00, sizeof(user));
+	userlen = 0;
+	(void)memset(passwd, 0x00, sizeof(passwd));
+	passwdlen = 0;
+	(void)memset(name, 0x00, sizeof(name));
+	namelen = 0;
+	return _ocesqlConnect(st, user, userlen, passwd, passwdlen, name, namelen, atdbbuf);
+}
+
 static int
 _ocesqlConnect(struct sqlca_t *st, char *user, int userlen, char *passwd, int passwdlen, char *name, int namelen, char *atdb){
 	char *dbuser, *dbpasswd, *dbname;

--- a/dblib/ocesql.h
+++ b/dblib/ocesql.h
@@ -39,8 +39,10 @@
 
 #ifdef _WIN32
 __declspec(dllexport) int OCESQLConnect(struct sqlca_t *, char *, int, char *, int, char *, int);
+__declspec(dllexport) int OCESQLConnectShort(struct sqlca_t *);
 __declspec(dllexport) int OCESQLConnectInformal(struct sqlca_t *, char *, int);
 __declspec(dllexport) int OCESQLIDConnect(struct sqlca_t *, char *, int, char *, int, char *, int, char *, int);
+__declspec(dllexport) int OCESQLIDConnectShort(struct sqlca_t *, char *, int);
 __declspec(dllexport) int OCESQLIDConnectInformal(struct sqlca_t *, char *, int, char *, int);
 __declspec(dllexport) int OCESQLDisconnect(struct sqlca_t *);
 __declspec(dllexport) int OCESQLIDDisconnect(struct sqlca_t *, char*, int);

--- a/ocesql/parser.y
+++ b/ocesql/parser.y
@@ -244,7 +244,8 @@ HOSTTOKEN {
 }
 
 connectsql:
-EXECSQL connect identified otherdb using END_EXEC { put_exec_list(); }
+EXECSQL CONNECT otherdb END_EXEC { put_exec_list(); }
+| EXECSQL connect identified otherdb using END_EXEC { put_exec_list(); }
 | EXECSQL AT dbid connect END_EXEC { put_exec_list(); }
 | EXECSQL connect otherdb END_EXEC { put_exec_list(); }
 

--- a/ocesql/ppout.c
+++ b/ocesql/ppout.c
@@ -415,7 +415,19 @@ void ppoutputconnect(struct cb_exec_list *list){
 		list_count++;
 		host_list = host_list->next;
 	}
-	if(list_count == 1){
+	if(list_count == 0){
+		if(list->conn_use_other_db){
+			memset(buff, 0, sizeof(buff));
+			com_sprintf(buff,sizeof(buff), "OCESQL%5sCALL \"OCESQLIDConnectShort\" USING\n"," ");
+			fputs(buff, outfile);
+			_printlog("Generate:OCESQLIDConnectShort");
+		} else {
+			memset(buff, 0, sizeof(buff));
+			com_sprintf(buff,sizeof(buff), "OCESQL%5sCALL \"OCESQLConnectShort\" USING\n"," ");
+			fputs(buff, outfile);
+			_printlog("Generate:OCESQLConnectShort");
+		}
+	}else if(list_count == 1){
 		if(list->conn_use_other_db){
 			memset(buff, 0, sizeof(buff));
 			com_sprintf(buff,sizeof(buff), "OCESQL%5sCALL \"OCESQLIDConnectInformal\" USING\n"," ");


### PR DESCRIPTION
引数無しのCONNECT文を受け付けるように対応した。
この場合、環境変数を参照し、CONNECT処理を実行する。