### PR TITLE
fix(ocesql): プリコンパイルのログ出力を改善

### DIFF
--- a/ocesql/ocesql.c
+++ b/ocesql/ocesql.c
@@ -404,11 +404,11 @@ int main (int argc, char *argv[])
 		}
 		filenameID = com_strdup(tempid);
 	}
-
-	printf("precompile start: %s\n",transfile.source);
-	printf("=======================================================\n");
-	printf("              LIST OF CALLED DB Library API            \n");
-	printf("=======================================================\n");
+	openerrorfile(errorfilename);
+	printmsg("precompile start: %s\n",transfile.source);
+	printmsg("=======================================================\n");
+	printmsg("              LIST OF CALLED DB Library API            \n");
+	printmsg("=======================================================\n");
 
 	processid = com_getpid();
 
@@ -427,15 +427,15 @@ int main (int argc, char *argv[])
 		flag_external=0;
 
 	iret = translate(&transfile);
-	printf("=======================================================\n");
+	printmsg("=======================================================\n");
 
 	free(filenameID);
 
-	if(iret != 0){
-		printf("translate error\n");
-		return 1;
-	}
 
-	return 0;
+	if(iret != 0){
+		printmsg("translate error\n");
+	}
+	closeerrorfile();
+	return iret;
 
 }

--- a/ocesql/ocesql.h
+++ b/ocesql/ocesql.h
@@ -259,7 +259,12 @@ void
 parameter_split(struct cb_field *vp_parent);
 
 extern int
-printerrormsg(char *name, int line, char * code, char *filename);
-
+openerrorfile(char *filename);
+extern int
+closeerrorfile();
+extern int
+printerrormsg(char *name, int line, char * code);
+extern int
+printmsg(char *format, ...);
 #endif
 

--- a/ocesql/ocesqlutil.c
+++ b/ocesql/ocesqlutil.c
@@ -150,7 +150,7 @@ com_readline(FILE *readfile, char *inbuff, int *lineno, int *eofflg){
 	} else if(feof(readfile)){
 		*eofflg = 1;
 	} else {
-		printf("com_readline: although EOF wasn't detected, fgets() returned NULL ");
+		printmsg("com_readline: although EOF wasn't detected, fgets() returned NULL ");
 		*eofflg = 1;
 	}
 	*lineno = *lineno + 1;

--- a/ocesql/parser.y
+++ b/ocesql/parser.y
@@ -41,7 +41,7 @@
 
 	int yyerror(const char *msg)
 	{
-	  	printf("%06d:%s\n", yylineno,msg);
+	  	printmsg("%06d:%s\n", yylineno,msg);
 		return 0;
 	}
 
@@ -433,7 +433,7 @@ VARYING
 {
 	if(current_field->pictype != PIC_ALPHANUMERIC &&
 		current_field->pictype != PIC_NATIONAL){
-		printf("parse error: %s specified the data types are not available to VARYING\n",
+		printmsg("parse error: %s specified the data types are not available to VARYING\n",
 		       current_field->sname);
 		exit(-1);
 	}
@@ -744,7 +744,7 @@ struct cb_field * cb_build_field_tree(int level, char *name , struct cb_field *l
 		}
 	} else {
 		if(last_field == NULL){
-			printf("parse error: %s level should start from 01 or 66 or 77 or 88\n", name);
+			printmsg("parse error: %s level should start from 01 or 66 or 77 or 88\n", name);
 			exit(-1);
 			return NULL;
 		}
@@ -903,7 +903,7 @@ check_has_occurs_children(struct cb_field *field){
 	if(field == NULL)
 		return 0;
 
-	printf("CHILDR:sname=%s, level=%d, occurs=%d, children=%d",
+	printmsg("CHILDR:sname=%s, level=%d, occurs=%d, children=%d",
 	       field->sname, field->level, field->occurs, field->children);
 
 	if(field->occurs != 0){

--- a/ocesql/ppout.c
+++ b/ocesql/ppout.c
@@ -450,7 +450,7 @@ void ppoutputconnect(struct cb_exec_list *list){
 		if(iret != 0){
 			memset(buff, 0, sizeof(buff));
 			com_sprintf(buff,sizeof(buff), "E%03d",iret);
-			printerrormsg(list->dbName, lineNUM, buff, errorfilename);
+			printerrormsg(list->dbName, lineNUM, buff);
 			return;
 		}
 		memset(buff, 0, sizeof(buff));
@@ -469,7 +469,7 @@ void ppoutputconnect(struct cb_exec_list *list){
 		{
 			memset(buff, 0, sizeof(buff));
 			com_sprintf(buff,sizeof(buff), "E%03d",iret);
-			printerrormsg(host_list->hostreference, host_list->lineno, buff, errorfilename);
+			printerrormsg(host_list->hostreference, host_list->lineno, buff);
 			return;
 		}
 		memset(buff, 0, sizeof(buff));
@@ -531,7 +531,7 @@ int ppoutputparam(struct cb_hostreference_list *host_list, int iteration){
 	{
 		memset(buff, 0, sizeof(buff));
 		com_sprintf(buff,sizeof(buff), "E%03d",iret);
-		printerrormsg(host_list->hostreference, host_list->lineno, buff, errorfilename);
+		printerrormsg(host_list->hostreference, host_list->lineno, buff);
 		return 0;
 	}
 
@@ -540,11 +540,11 @@ int ppoutputparam(struct cb_hostreference_list *host_list, int iteration){
 
 		f = getfieldbyname(host_list->hostreference);
 		if(f == NULL){
-			printf("%s:%d\n", host_list->hostreference, ERR_NOTDEF_WORKING);
+			printmsg("%s:%d\n", host_list->hostreference, ERR_NOTDEF_WORKING);
 			memset(buff, 0, sizeof(buff));
 			com_sprintf(buff,sizeof(buff), "E%03d",ERR_NOTDEF_WORKING);
 			printerrormsg(host_list->hostreference, host_list->lineno,
-					buff, errorfilename);
+					buff);
 			return count;
 		}
 
@@ -556,7 +556,7 @@ int ppoutputparam(struct cb_hostreference_list *host_list, int iteration){
 			{
 				memset(buff, 0, sizeof(buff));
 				com_sprintf(buff,sizeof(buff), "E%03d",iret);
-				printerrormsg(f->sname, host_list->lineno, buff, errorfilename);
+				printerrormsg(f->sname, host_list->lineno, buff);
 				return count;
 			}
 			_ppoutputparam(f->sname, type, digits, scale, iteration);
@@ -614,10 +614,10 @@ void ppoutputresgroup(struct cb_field *cf, int lineno, int iteration){
 
 	iret = gethostvarianttype(cf->sname, &type, &digits, &scale);
 	if(iret != 0){
-		printf("%s:%d\n", cf->sname, iret);
+		printmsg("%s:%d\n", cf->sname, iret);
 		memset(buff, 0, sizeof(buff));
 		com_sprintf(buff,sizeof(buff), "E%03d",iret);
-		printerrormsg(cf->sname, lineno, buff, errorfilename);
+		printerrormsg(cf->sname, lineno, buff);
 		return;
 	}
 
@@ -650,11 +650,11 @@ void ppoutputexecprepare(struct cb_exec_list *list){
 	if(host_list){
 		iret = gethostvarianttype(host_list->hostreference, &type, &digits, &scale);
 		if(iret != 0){
-			printf("%s:%d\n", host_list->hostreference,iret);
+			printmsg("%s:%d\n", host_list->hostreference,iret);
 			memset(buff, 0, sizeof(buff));
 			com_sprintf(buff,sizeof(buff), "E%03d",iret);
 			printerrormsg(host_list->hostreference, host_list->lineno,
-					buff, errorfilename);
+					buff);
 			return;
 		}
 
@@ -688,7 +688,7 @@ void ppoutputexecprepare(struct cb_exec_list *list){
 		{
 			memset(buff, 0, sizeof(buff));
 			com_sprintf(buff,sizeof(buff), "E%03d",iret);
-			printerrormsg(list->dbName, lineNUM, buff, errorfilename);
+			printerrormsg(list->dbName, lineNUM, buff);
 			return;
 		}
 
@@ -742,11 +742,11 @@ void ppoutputfetch(struct cb_exec_list *list){
 
 	iret = gethostvarianttype(res_host_list->hostreference, &type, &digits, &scale);
 	if(iret != 0){
-		printf("%s:%d\n", res_host_list->hostreference,iret);
+		printmsg("%s:%d\n", res_host_list->hostreference,iret);
 		memset(buff, 0, sizeof(buff));
 		com_sprintf(buff,sizeof(buff), "E%03d",iret);
 		printerrormsg(res_host_list->hostreference, res_host_list->lineno,
-					  buff, errorfilename);
+					  buff);
 		return;
 	}
 
@@ -755,11 +755,11 @@ void ppoutputfetch(struct cb_exec_list *list){
 
 		parent = getfieldbyname(res_host_list->hostreference);
 		if(parent == NULL){
-			printf("%s:%d\n", res_host_list->hostreference, ERR_NOTDEF_WORKING);
+			printmsg("%s:%d\n", res_host_list->hostreference, ERR_NOTDEF_WORKING);
 			memset(buff, 0, sizeof(buff));
 			com_sprintf(buff,sizeof(buff), "E%03d",ERR_NOTDEF_WORKING);
 			printerrormsg(res_host_list->hostreference, res_host_list->lineno,
-						  buff, errorfilename);
+						  buff);
 			return;
 		}
 
@@ -772,7 +772,7 @@ void ppoutputfetch(struct cb_exec_list *list){
 			if(iret != 0){
 				memset(buff, 0, sizeof(buff));
 				com_sprintf(buff,sizeof(buff), "E%03d",iret);
-				printerrormsg(res_host_list->hostreference, res_host_list->lineno, buff, errorfilename);
+				printerrormsg(res_host_list->hostreference, res_host_list->lineno, buff);
 				return;
 			}
 		} else {
@@ -784,7 +784,7 @@ void ppoutputfetch(struct cb_exec_list *list){
 			if(iret != 0){
 				memset(buff, 0, sizeof(buff));
 				com_sprintf(buff,sizeof(buff), "E%03d",iret);
-				printerrormsg(res_host_list->hostreference, res_host_list->lineno, buff, errorfilename);
+				printerrormsg(res_host_list->hostreference, res_host_list->lineno, buff);
 				return;
 			}
 		}
@@ -796,7 +796,7 @@ void ppoutputfetch(struct cb_exec_list *list){
 				memset(buff, 0, sizeof(buff));
 				com_sprintf(buff,sizeof(buff), "E%03d",iret);
 				printerrormsg(res_host_list->hostreference, res_host_list->lineno,
-							  buff, errorfilename);
+							  buff);
 				return;
 			}
 			ppoutputresparam(res_host_list->hostreference, type, digits, scale,iteration);
@@ -895,7 +895,7 @@ void ppoutputcommit(struct cb_exec_list *list){
 		{
 			memset(buff, 0, sizeof(buff));
 			com_sprintf(buff,sizeof(buff), "E%03d",iret);
-			printerrormsg(list->dbName, lineNUM, buff, errorfilename);
+			printerrormsg(list->dbName, lineNUM, buff);
 			return;
 		}
 
@@ -960,7 +960,7 @@ void ppoutputrollback(struct cb_exec_list *list){
 		{
 			memset(buff, 0, sizeof(buff));
 			com_sprintf(buff,sizeof(buff), "E%03d",iret);
-			printerrormsg(list->dbName, lineNUM, buff, errorfilename);
+			printerrormsg(list->dbName, lineNUM, buff);
 			return;
 		}
 
@@ -1016,22 +1016,22 @@ void ppoutputprepare(struct cb_exec_list *list){
 	{
 		memset(buff, 0, sizeof(buff));
 		com_sprintf(buff,sizeof(buff), "E%03d",iret);
-		printerrormsg(list->host_list->hostreference, list->host_list->lineno, buff, errorfilename);
+		printerrormsg(list->host_list->hostreference, list->host_list->lineno, buff);
 		return;
 	} else if(l != HVARTYPE_GROUP){
 		memset(buff, 0, sizeof(buff));
 		com_sprintf(buff,sizeof(buff), "E%03d",ERR_PREPARE_ISNT_GROUP);
-		printerrormsg(list->host_list->hostreference, list->host_list->lineno, buff, errorfilename);
+		printerrormsg(list->host_list->hostreference, list->host_list->lineno, buff);
 		return;
 	}
 
 	parent = getfieldbyname(list->host_list->hostreference);
 	if(parent == NULL){
-	     printf("%s:%d\n", list->host_list->hostreference, ERR_NOTDEF_WORKING);
+	     printmsg("%s:%d\n", list->host_list->hostreference, ERR_NOTDEF_WORKING);
 	     memset(buff, 0, sizeof(buff));
 	     com_sprintf(buff,sizeof(buff), "E%03d",ERR_NOTDEF_WORKING);
 	     printerrormsg(list->host_list->hostreference, list->host_list->lineno,
-			   buff, errorfilename);
+			   buff);
 	     return;
 	}
 
@@ -1049,7 +1049,7 @@ void ppoutputprepare(struct cb_exec_list *list){
 	     memset(buff, 0, sizeof(buff));
 	     com_sprintf(buff,sizeof(buff), "E%03d",ERR_PREPARE_INVALID_PARAM);
 	     printerrormsg(list->host_list->hostreference, list->host_list->lineno,
-			   buff, errorfilename);
+			   buff);
 	     free(comp_varname);
 	     return;
 	}
@@ -1060,7 +1060,7 @@ void ppoutputprepare(struct cb_exec_list *list){
 	     memset(buff, 0, sizeof(buff));
 	     com_sprintf(buff,sizeof(buff), "E%03d",ERR_PREPARE_INVALID_PARAM);
 	     printerrormsg(list->host_list->hostreference, list->host_list->lineno,
-			   buff, errorfilename);
+			   buff);
 	     free(comp_varname);
 	     return;
 	}
@@ -1103,7 +1103,7 @@ void ppoutputdisconnect(struct cb_exec_list *list){
 		{
 			memset(buff, 0, sizeof(buff));
 			com_sprintf(buff,sizeof(buff), "E%03d",iret);
-			printerrormsg(list->dbName, lineNUM, buff, errorfilename);
+			printerrormsg(list->dbName, lineNUM, buff);
 			return;
 		}
 
@@ -1150,7 +1150,7 @@ void ppoutputother(struct cb_exec_list *list){
 			{
 				memset(buff, 0, sizeof(buff));
 				com_sprintf(buff,sizeof(buff), "E%03d",iret);
-				printerrormsg(list->dbName, lineNUM, buff, errorfilename);
+				printerrormsg(list->dbName, lineNUM, buff);
 				return;
 			}
 
@@ -1276,7 +1276,7 @@ exit_occurs_check:
 		{
 			memset(buff, 0, sizeof(buff));
 			com_sprintf(buff,sizeof(buff), "E%03d",iret);
-			printerrormsg(list->dbName, lineNUM, buff, errorfilename);
+			printerrormsg(list->dbName, lineNUM, buff);
 			return;
 		}
 
@@ -1571,7 +1571,7 @@ void ppbuff(struct cb_exec_list *list){
 				{
 					memset(buff, 0, sizeof(buff));
 					com_sprintf(buff,sizeof(buff), "E%03d",iret);
-					printerrormsg(list->dbName, lineNUM, buff, errorfilename);
+					printerrormsg(list->dbName, lineNUM, buff);
 					return;
 				}
 
@@ -1651,7 +1651,7 @@ void ppbuff(struct cb_exec_list *list){
 				memset(buff, 0, sizeof(buff));
 				com_sprintf(buff,sizeof(buff), "E%03d",iret);
 				printerrormsg(wk_res_host->hostreference, wk_res_host->lineno,
-							  buff, errorfilename);
+							  buff);
 				return;
 			}
 
@@ -1660,11 +1660,11 @@ void ppbuff(struct cb_exec_list *list){
 
 				parent = getfieldbyname(wk_res_host->hostreference);
 				if(parent == NULL){
-					printf("%s:%d\n", wk_res_host->hostreference, ERR_NOTDEF_WORKING);
+					printmsg("%s:%d\n", wk_res_host->hostreference, ERR_NOTDEF_WORKING);
 					memset(buff, 0, sizeof(buff));
 					com_sprintf(buff,sizeof(buff), "E%03d",ERR_NOTDEF_WORKING);
 					printerrormsg(wk_res_host->hostreference, wk_res_host->lineno,
-								  buff, errorfilename);
+								  buff);
 					return;
 				}
 
@@ -1678,7 +1678,7 @@ void ppbuff(struct cb_exec_list *list){
 						memset(buff, 0, sizeof(buff));
 						com_sprintf(buff,sizeof(buff), "E%03d",iret);
 						printerrormsg(wk_res_host->hostreference, wk_res_host->lineno,
-									  buff, errorfilename);
+									  buff);
 						return;
 					}
 				} else {
@@ -1690,7 +1690,7 @@ void ppbuff(struct cb_exec_list *list){
 						memset(buff, 0, sizeof(buff));
 						com_sprintf(buff,sizeof(buff), "E%03d",iret);
 						printerrormsg(wk_res_host->hostreference, wk_res_host->lineno,
-									  buff, errorfilename);
+									  buff);
 						return;
 					}
 				}
@@ -1700,7 +1700,7 @@ void ppbuff(struct cb_exec_list *list){
 					if(iret != 0){
 						memset(buff, 0, sizeof(buff));
 						com_sprintf(buff,sizeof(buff), "E%03d",iret);
-						printerrormsg(child->sname, wk_res_host->lineno, buff, errorfilename);
+						printerrormsg(child->sname, wk_res_host->lineno, buff);
 						return;
 					}
 					ppoutputresparam(child->sname, var_type, var_len, var_scale,iteration);
@@ -1716,7 +1716,7 @@ void ppbuff(struct cb_exec_list *list){
 						memset(buff, 0, sizeof(buff));
 						com_sprintf(buff,sizeof(buff), "E%03d",iret);
 						printerrormsg(wk_res_host->hostreference, wk_res_host->lineno,
-									  buff, errorfilename);
+									  buff);
 						return;
 					}
 
@@ -1784,7 +1784,7 @@ void ppbuff(struct cb_exec_list *list){
 				{
 					memset(buff, 0, sizeof(buff));
 					com_sprintf(buff,sizeof(buff), "E%03d",iret);
-					printerrormsg(list->dbName, lineNUM, buff, errorfilename);
+					printerrormsg(list->dbName, lineNUM, buff);
 					return;
 				}
 
@@ -1855,7 +1855,7 @@ void ppbuff(struct cb_exec_list *list){
 			{
 				memset(buff, 0, sizeof(buff));
 				com_sprintf(buff,sizeof(buff), "E%03d",iret);
-				printerrormsg(list->dbName, lineNUM, buff, errorfilename);
+				printerrormsg(list->dbName, lineNUM, buff);
 				return;
 			}
 
@@ -1964,7 +1964,7 @@ void ppbuff_incfile(struct cb_exec_list *list){
 			if(strlen(incf_buff) > MAX_LINESIZE){
 				memset(buff, 0, sizeof(buff));
 				com_sprintf(buff,sizeof(buff), "E%03d",ERR_EXCEED_LIMIT_LINE_LENGTH);
-				printerrormsg("", lineNUM, buff, errorfilename);
+				printerrormsg("", lineNUM, buff);
 			}
 
 			com_strcpy(out,sizeof(out),"OCESQL");
@@ -2202,7 +2202,7 @@ void parameter_split(struct cb_field *vp_parent){
 	vp_len = malloc(sizeof(struct cb_field));
 	vp_arr = malloc(sizeof(struct cb_field));
 	if( vp_len == NULL || vp_arr == NULL){
-	     printf("parameter_split: memory allocation for cb_field failed.\n");
+	     printmsg("parameter_split: memory allocation for cb_field failed.\n");
 	     goto die_parameter_split;
 	     return;
 	}
@@ -2217,7 +2217,7 @@ void parameter_split(struct cb_field *vp_parent){
 	// vp_len
 	vp_len->sname = (char *)malloc((strlen(basename) + strlen("-LEN") + TERMINAL_LENGTH) * sizeof(char));
 	if(vp_len->sname == NULL){
-	     printf("parameter_split: memory allocation for vp_len->sname failed.\n");
+	     printmsg("parameter_split: memory allocation for vp_len->sname failed.\n");
 	     goto die_parameter_split;
 	     return;
 	}
@@ -2233,7 +2233,7 @@ void parameter_split(struct cb_field *vp_parent){
 	// vp_arr
 	vp_arr->sname = (char *)malloc((strlen(basename) + strlen("-ARR") + TERMINAL_LENGTH) * sizeof(char));
 	if(vp_arr->sname == NULL){
-	     printf("parameter_split: memory allocation for vp_arr->sname failed.\n");
+	     printmsg("parameter_split: memory allocation for vp_arr->sname failed.\n");
 	     goto die_parameter_split;
 	     return;
 	}
@@ -2281,5 +2281,5 @@ FILE* fopen_or_die(char *filename, const char *mode){
 }
 
 void _printlog(char *msg){
-	printf("%s\n", msg);
+	printmsg("%s\n", msg);
 }

--- a/ocesql/scanner.l
+++ b/ocesql/scanner.l
@@ -774,7 +774,7 @@ yyinput(char *buff,int max_size)
     				return strlen(buff);
 
 			default:
-	                        printf("EOF:%s\n", buff);
+				printmsg("EOF:%s\n", buff);
 				return YY_NULL;
 			}
 			if(strlen(buff) > 72){


### PR DESCRIPTION
プリコンパイル実行時の各種情報が標準出力にのみ出力されていたため、関数で共通化した。
ログファイル指定がある場合、そちらに出力する。