### PR TITLE
fix(ocesql): 未定義変数をINSERT文等で利用した際のエラーに対応

### DIFF
--- a/ocesql/ppout.c
+++ b/ocesql/ppout.c
@@ -1187,9 +1187,13 @@ void ppoutputother(struct cb_exec_list *list){
 		int iret;
 
 		res_host_list = list->host_list;
-		struct cb_field *parent, *child;
+		struct cb_field *parent, *child, *f;
+		f = getfieldbyname(res_host_list->hostreference);
+		if (f == NULL){
+			goto exit_occurs_check;
+		}
 
-		parent = getfieldbyname(res_host_list->hostreference)->parent;
+		parent = f->parent;
 		if(parent == NULL){
 			goto exit_occurs_check;
 		}


### PR DESCRIPTION
INSERT文、DELETE文、UPDATE文で未定義のフィールド名をホスト変数として利用した際に、
Segmentation faultが発生する問題を修正した。