### PR TITLE
fix(dblib): Postgresqlで同名のカーソルを再度オープンした際エラーとなる現象を修正

### DIFF
--- a/dblib/ocdb.c
+++ b/dblib/ocdb.c
@@ -297,7 +297,8 @@ OCDBCursorOpen(int id, char *cname){
 	p_conn->result = RESULT_SUCCESS;
 
 #ifdef PGSQL_MODE_ON
-	// nothing to do
+	// dummy
+	p_conn->result = RESULT_FLAG1_PGSQL_DUMMYOPEN;
 	return;
 #endif
 
@@ -417,14 +418,20 @@ OCDBSetResultStatus(int id, struct sqlca_t *st){
 		return RESULT_ERROR;
 	}
 
-	if(p_conn->resaddr == OCDB_RES_DEFAULT_ADDRESS){
+	if(p_conn->resaddr == OCDB_RES_DEFAULT_ADDRESS &&
+		p_conn->result <= RESULT_FLAGBASE){
 		// 結果リソースが無いため成功で返す
 	  //return OCDB_RES_COMMAND_OK;
 		return RESULT_ERROR;
 	}
 
 #ifdef PGSQL_MODE_ON
-	retval = OCDB_PGSetResultStatus(p_conn->resaddr,st);
+	if(p_conn->result == RESULT_FLAG1_PGSQL_DUMMYOPEN){
+		// DUMMY OPENの対応
+		retval = RESULT_SUCCESS;
+	} else {
+		retval = OCDB_PGSetResultStatus(p_conn->resaddr,st);
+	}
 #endif
 	return retval;
 }

--- a/dblib/ocdb.h
+++ b/dblib/ocdb.h
@@ -38,6 +38,8 @@ typedef struct lock_conn {
 #define RESULT_FAILED -1
 #define RESULT_SUCCESS 0
 #define RESULT_ERROR -2
+#define RESULT_FLAGBASE 10
+#define RESULT_FLAG1_PGSQL_DUMMYOPEN 11
 
 // default resource address
 #define OCDB_RES_DEFAULT_ADDRESS 0


### PR DESCRIPTION
PostgresqlではDeclareの時点でカーソルが作成されるため、Openはダミー処理となっている。
ダミー処理の際に、誤ってRESULT_ERRORが上位関数に戻される仕様となっていたため、カーソルのCloseが正常に行われていなかった。
DUMMY処理の場合のステータスを別途作成し、この問題に対応した。

Please see the issue for details
#12 