### PR TITLE
fix(ocesql): INCLUDE後のエラーメッセージで行番号が異なる

### DIFF
--- a/ocesql/ocesql.h
+++ b/ocesql/ocesql.h
@@ -93,6 +93,9 @@ enum oc_usage{
 #define incfolder     "INC"
 #define copypath      "sqlca.cbl"
 
+#define INC_START_MARK  ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+#define INC__END__MARK  "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+
 struct filename {
 	char  *source;
 	char  *translate;

--- a/ocesql/ppout.c
+++ b/ocesql/ppout.c
@@ -1937,6 +1937,7 @@ void ppbuff(struct cb_exec_list *list){
 void ppbuff_incfile(struct cb_exec_list *list){
 	struct cb_exec_list *l;
 	char buff[10];
+	char incmsg[256];
 	int len2;
 
 	l = list;
@@ -1955,6 +1956,11 @@ void ppbuff_incfile(struct cb_exec_list *list){
 		com_strcat(filename,sizeof(filename), l->incfileName);
  
  		incf = fopen_or_die(filename, "r");
+
+		memset(incmsg, 0, 256);
+		sprintf(incmsg, "%s incfile start:%s", INC_START_MARK, filename);
+		com_strcpy(out,sizeof(out),incmsg);
+		outwrite();
 
 		while(1){
 			memset(incf_buff, 0, BUFFSIZE + 1);
@@ -1976,6 +1982,12 @@ void ppbuff_incfile(struct cb_exec_list *list){
 			}
 			outwrite();
 		}
+
+		memset(incmsg, 0, 256);
+		sprintf(incmsg, "%s incfile end:%s",INC__END__MARK , filename);
+		com_strcpy(out,sizeof(out),incmsg);
+		outwrite();
+
 		return;
 	}
 	return;
@@ -2006,6 +2018,10 @@ void ppoutput(char *ppin,char *ppout,struct cb_exec_list *head){
 	if (readfile && outfile){
 		for(;EOFflg != 1;){
 			com_readline(readfile, inbuff, &lineNUM, &EOFflg);
+			if(strstr(inbuff, INC_START_MARK) != NULL ||
+			strstr(inbuff, INC__END__MARK) != NULL){
+				continue;
+			}
 			if(head){
 				if (l->startLine<= lineNUM && l->endLine>=lineNUM){
 					if(strcmp(l->commandName,"WORKING_END")==0){
@@ -2107,7 +2123,6 @@ void ppoutput_incfile(char *ppin,char *ppout,struct cb_exec_list *head){
 
 					if (EOFflg == 1){
 						fputc('\n',outfile);
-
 					}
 				}
 				else{

--- a/ocesql/scanner.l
+++ b/ocesql/scanner.l
@@ -38,6 +38,8 @@
 int startlineno = 0;
 int endlineno = 0;
 int hostlineno = 0;
+int includelinenum = 0;
+int includeflag = 0;
 int period = 0;
 int conn_use_other_db = 0;
 int command_putother = 0;
@@ -321,7 +323,7 @@ INT_CONSTANT {digit}+
 <ESQL_DBNAME_STATE>{
 	{HOSTWORD} {
 		yylval.s = com_strdup (yytext + 1);
-		hostlineno = yylineno;
+		hostlineno = yylineno - includelinenum;
 
 		yy_pop_state();
 		return HOSTTOKEN;
@@ -434,7 +436,7 @@ INT_CONSTANT {digit}+
 
 	{HOSTWORD} {
 			yylval.s = com_strdup (yytext + 1);
-			hostlineno = yylineno;
+			hostlineno = yylineno - includelinenum;
 
 			return HOSTTOKEN;
 	}
@@ -733,6 +735,25 @@ yyinput(char *buff,int max_size)
 	{
 		if(strlen(buff) > 7)
 		{
+			if(strstr(buff, INC_START_MARK) != NULL){
+				includeflag = 1;
+				includelinenum++;
+				/* ignore line */
+				com_strcpy(buff,max_size,"\n");
+	    		return strlen(buff);
+			}
+			if(includeflag){
+				includelinenum++;
+			}
+			if(strstr(buff, INC__END__MARK) != NULL){
+				includeflag = 0;
+				/* ignore line */
+				com_strcpy(buff,max_size,"\n");
+	    		return strlen(buff);
+			}
+			
+			
+		
 			bp = buff + 7;
 
 			switch (buff[6]) {


### PR DESCRIPTION
EXEC SQL INCLUDEの後続の命令に関して、エラー、ワーニングがあった場合に出力されている行番号が異なっていた。
INCLUDEで展開さえたファイルの行数を無視するように修正。