### PR TITLE
logging improvements

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,6 @@ Japan Pulp and Paper Information Center Co., Ltd.
 
 OSS Consortium / Open COBOL Solution Working Group <ws-opensource-cobol-contact@osscons.jp>
 	for bug-reporting and improvement suggestion.
+
+Simon Sobisch <simonsobisch@gnu.org>
+    for bugfixes and performance updates

--- a/dblib/ChangeLog
+++ b/dblib/ChangeLog
@@ -1,4 +1,25 @@
 
+2022-02-02  Simon Sobisch <simonsobisch@gnu.org>
+
+	* ocdblog.h, ocdblog.c, odbcutil.c, odbcutil.h:
+	  changed magic numbers to enum ocloglevel, 
+	  use a single static loglevel instead of one for each source
+	* ocesql.c (OCESQLEndSQL, add_prepare_list): only run debug logging
+	  code if debug logging is active
+	* ocesql.c (create_coboldata) [!NDEBUG]: send data to logging
+	  without unnecessary temporary string duplication 
+	* ocdblog.h: changed definitions for LOG and ERRLOG to only call the
+	  logging functions if the current loglevel is either unknown or
+	  set to actually do that logging which saves a lot of stack changes
+	  (nice for 'step'ing with the debugger and for saving cpu cycles if
+	  logging is disabled)
+	* ocdbutil.c (com_get_logfile): simplified
+	* ocdbutil.c (env_to_loglevel): extracted from com_get_loglevel,
+	  changed default from "no log" to "log only errors"
+	* ocdbutil.c (com_get_logfile) [_WIN32]: changed default log path
+	  to current working directory instead of D:\develop
+	* ocdbutil.c (com_sleep, com_strdup): inlined calculation
+
 2021-07-05  Simon Sobisch <simonsobisch@gnu.org>
 
 	* Makefile.am: added EXTRA_DIST to ship headers, necessary for make dist

--- a/dblib/ocdblog.c
+++ b/dblib/ocdblog.c
@@ -1,4 +1,5 @@
 ﻿/*
+ * Copyright (C) 2015, 2022 Tokyo System House Co.,Ltd.
  * Copyright (C) 2022 Tokyo System House Co.,Ltd.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -23,6 +24,9 @@
 #include <time.h>
 #include "ocdbutil.h"
 #include "ocdblog.h"
+
+enum ocloglevel loglevel = LOG_OUTPUT_NOTSET;
+char *logfile = NULL;
 
 void OCLOG(const char *file, const char *func, const char *format, ...){
 	if(loglevel == LOG_OUTPUT_NOTSET){

--- a/dblib/ocdblog.h
+++ b/dblib/ocdblog.h
@@ -1,5 +1,6 @@
 ﻿/*
- * Copyright (C) 2022 Tokyo System House Co.,Ltd.
+ * Copyright (C) 2015, 2022 Tokyo System House Co.,Ltd.
+ * Copyright (C) 2022 Simon Sobisch
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,24 +16,29 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-
 #ifndef OCDBLOG_H /* OCDBLOG_H */
 #define OCDBLOG_H
 
-#define LOG_OUTPUT_NOTSET 0
-#define LOG_OUTPUT_NOTHING 1
-#define LOG_OUTPUT_ERR 2
-#define LOG_OUTPUT_DEBUG 3
+enum ocloglevel {
+    LOG_OUTPUT_NOTSET = 0,
+    LOG_OUTPUT_NOTHING = 1,
+    LOG_OUTPUT_ERR = 2,
+    LOG_OUTPUT_DEBUG = 3
+};
 
 #define LOGBUFSIZE 26
 
-static int loglevel = LOG_OUTPUT_NOTSET;
-static char* logfile = NULL;
+extern enum ocloglevel loglevel;
+extern char* logfile;
 
-#define LOG(...) {OCLOG(__FILE__, __FUNCTION__,__VA_ARGS__);}
-#define ERRLOG(...) {OCERRLOG(__FILE__, __FUNCTION__,__VA_ARGS__);}
+#define LOG(...) {if (loglevel == LOG_OUTPUT_NOTSET || loglevel == LOG_OUTPUT_DEBUG) OCLOG(__FILE__, __FUNCTION__,__VA_ARGS__);}
+#define ERRLOG(...) {if (loglevel != LOG_OUTPUT_NOTHING) OCERRLOG(__FILE__, __FUNCTION__,__VA_ARGS__);}
 
 void OCLOG(const char *, const char *, const char *, ...);
 void OCERRLOG(const char *, const char *, const char *, ...);
+
+/* actually defined in ocdbutil.h */
+enum ocloglevel com_get_loglevel();
+char *com_get_logfile();
 
 #endif

--- a/dblib/ocdbutil.h
+++ b/dblib/ocdbutil.h
@@ -1,5 +1,6 @@
 ﻿/*
- * Copyright (C) 2022 Tokyo System House Co.,Ltd.
+ * Copyright (C) 2015, 2022 Tokyo System House Co.,Ltd.
+ * Copyright (C) 2022 Simon Sobisch
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +15,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 
 #ifndef OCDBUTIL_H
 #define OCDBUTIL_H
@@ -52,8 +52,6 @@ void com_fopen(FILE**, const char *,const char *);
 char *com_strcpy(char *, size_t, const char*);
 char *com_ctime(char *, size_t, const time_t *);
 char *com_strncpy(char *, size_t, const char*, size_t);
-int com_get_loglevel();
-char *com_get_logfile();
 char *com_getenv(char *, char *);
 void com_fprint_log(FILE *, const char *, const char *);
 void com_fprint_elog(FILE *, const char *, const char *);

--- a/dblib/ocesql.c
+++ b/dblib/ocesql.c
@@ -1,5 +1,6 @@
 ﻿/*
- * Copyright (C) 2022 Tokyo System House Co.,Ltd.
+ * Copyright (C) 2015, 2022 Tokyo System House Co.,Ltd.
+ * Copyright (C) 2022 Simon Sobisch
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +15,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -2288,11 +2288,13 @@ OCESQLSetHostTable(int iter, int length, int is_parent){
  */
 int
 OCESQLEndSQL(void){
-	LOG("#debug start dump var_list\n");
-	show_sql_var_list(_sql_var_lists);
-	LOG("#debug start dump res_list\n");
-	show_sql_var_list(_sql_res_var_lists);
-	LOG("#debug end dump list\n");
+	if (loglevel == LOG_OUTPUT_DEBUG) {
+		LOG("#debug start dump var_list\n");
+		show_sql_var_list(_sql_var_lists);
+		LOG("#debug start dump res_list\n");
+		show_sql_var_list(_sql_res_var_lists);
+		LOG("#debug end dump list\n");
+	}
 
 	clear_sql_var_list(_sql_var_lists);
 	clear_sql_var_list(_sql_res_var_lists);
@@ -3228,14 +3230,7 @@ create_coboldata(SQLVAR *sv, int index, char *retstr){
 		break;
 	}
 #ifndef NDEBUG
-	char *tmp;
-	if(sv->type == OCDB_TYPE_JAPANESE){
-		tmp = oc_strndup((char *)addr,sv->length*2);
-	}else{
-		tmp = oc_strndup((char *)addr,sv->length);
-	}
-	LOG("%d %d#%s#%s#\n", sv->type, sv->length, retstr, tmp);
-	if(tmp) free(tmp);
+	LOG("%d %d#%s#%s#\n", sv->type, sv->length, retstr, (char *)addr);
 #endif
 }
 
@@ -3693,7 +3688,9 @@ add_prepare_list(char *sname, char *query, int nParams){
 	p->sq.query = query;
 	p->sq.nParams = nParams;
 
+	if(loglevel == LOG_OUTPUT_DEBUG){
 		show_prepare_list();
+	}
 
 	return p;
 }


### PR DESCRIPTION
* ocdblog.h, ocdblog.c, odbcutil.c, odbcutil.h: changed magic numbers to enum ocloglevel, use a single static loglevel instead of one for each source
* ocesql.c (OCESQLEndSQL, add_prepare_list): only run debug logging code if debug logging is active
* ocesql.c (create_coboldata) [!NDEBUG]: send data to logging without unnecessary temporary string duplication
* ocdblog.h: changed definitions for LOG and ERRLOG to only call the logging functions if the current loglevel is either unknown or set to actually do that logging which saves a lot of stack changes (nice for 'step'ing with the debugger and for saving cpu cycles if logging is disabled)
* ocdbutil.c (com_get_logfile): simplified
* ocdbutil.c (env_to_loglevel): extracted from com_get_loglevel, changed default from "no log" to "log only errors"
* ocdbutil.c (com_get_logfile) [_WIN32]: changed default log path to current working directory instead of D:\develop
* ocdbutil.c (com_sleep, com_strdup): inlined calculation

Note: my other changes that are related to performance, fixing memory leaks and buffer overflows (all in ocesql) will take longer to review, so I don't expect to do that in the next weeks; but definitely plan to do so "some time later"