### PR TITLE
Update: modify build_aux/bootstrap to run CI successfully.

### DIFF
--- a/.github/workflows/ubuntu-test.yml
+++ b/.github/workflows/ubuntu-test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libncurses5 libncurses5-dev libgmp-dev bison flex gettext automake autoconf
+          sudo apt-get install -y build-essential libncurses5 libncurses5-dev libgmp-dev bison flex gettext
           sudo apt-get install -y libpq-dev postgresql postgresql-contrib
       
       # Cache the directory 'opensource-cobol-1.5.2J'

--- a/build_aux/bootstrap
+++ b/build_aux/bootstrap
@@ -77,7 +77,7 @@ ret=0
 
 # ensure the configure and Makefile parts are up-to-date:
 #autoreconf --verbose --force --include=m4 $MAINPATH; ret=$?
-autoreconf --verbose --force $MAINPATH; ret=$?
+autoreconf --verbose --force --install $MAINPATH; ret=$?
 
 if test $ret -ne 0; then
   echo; echo "ERROR, autoreconf returned $ret - aborting bootstrap" && exit $ret


### PR DESCRIPTION
The installation process fails when executing CI.
https://github.com/yutaro-sakamoto/Open-COBOL-ESQL/runs/6017559766?check_suite_focus=true

I modified build_aux/bootstrap and solved the problem.
@GitMensch, are there any problems with this change?