### PR TITLE
replace '#include <malloc.h>' with standard <stdlib.h>

### DIFF
--- a/dblib/ocdb.c
+++ b/dblib/ocdb.c
@@ -17,7 +17,7 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "ocdblog.h"
 #include "ocdb.h"
 #include "ocdbutil.h"

--- a/dblib/ocdbutil.c
+++ b/dblib/ocdbutil.c
@@ -21,7 +21,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include <stdbool.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <math.h>
 #include "ocdbutil.h"
 #include "ocdblog.h"

--- a/dblib/ocesql.c
+++ b/dblib/ocesql.c
@@ -22,7 +22,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <math.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <ctype.h>
 #include "ocdblog.h"
 #include "ocdbutil.h"

--- a/dblib/ocpgsql.c
+++ b/dblib/ocpgsql.c
@@ -17,10 +17,9 @@
 
 
 #include <stdio.h>
-#include <string.h>
-#include <malloc.h>
-#include <math.h>
 #include <stdlib.h>
+#include <string.h>
+#include <math.h>
 
 #include "ocpgsql.h"
 #include "ocdblog.h"


### PR DESCRIPTION
This is a cherry-pick of 72f2f6ee0c261ffc1f8219810e35bdf47a1839f1 done by @ChihHao-Su (+conflicts solved) and was merged by @yutaro-sakamoto in September 2022 into a stale branch in #69.

As this part from the initial PR is still not integrated and missing I suggest to pull this in (and delete the stale branch "[feature/openbsd](https://github.com/opensourcecobol/Open-COBOL-ESQL/tree/feature/openbsd)" afterwards).