### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -74,19 +74,30 @@ See also AUTHORS for the author and contributors.
 5. Installation
 ===============
 
-To install Ocesql:
+To install Ocesql (PostgreSQL 9.0 or above):  
+Before running "configure", you'll need to tell ocesql where your include PostgreSQL include files such as "libpq-fe.h" are, 
+and also possibly the library location.  These vary by PostgreSQL version and distribution, but on a recent Ubuntu with PostgreSQL 14 this will be something like:
 
-    ./configure
-    make
-    make install
+    export CPPFLAGS="-I/usr/include/postgresql"
 
-For use with PostgreSQL 9.0 or later:
+An earlier version (PostgreSQL 9) might be:
 
     export CPPFLAGS="-I/usr/pgsql-9.x/include"
     export LDFLAGS="-L/usr/pgsql-9.x/lib"
+    
+Then run:
+
     ./configure
     make
     make install
+    
+If you want to install Ocesql on PostgreSQL < 9, just:
+
+    ./configure
+    make
+    make install
+
+
 
 The "make install" will default to "/usr/local" as the install path.
 You may override this by specifying "--prefix=<your install path>" 
@@ -106,23 +117,23 @@ following programs:
                        FETCH cursor, COMMIT, ROLLBACK, DISCONNECT
 
 * Note that these sample programs includes Japanese Shift-JIS characters.
-  If you wish to run on non-Japanese environment, modify them first.
+  If you wish to run on non-Japanese environment, modify them first so that the commented-out lines containing non-Japanese text are used in place of the Japanese ones.
 
 To run the sample programs: 
 
   1) Create a sample database named "testdb"
 
-     When PostgreSQL:
+     When PostgreSQL (non-Japanese):
 
        createdb -T template0 testdb
 
-       If working on Japanese environment, encoding should be UTF-8.
+     Or, if working in a Japanese environment, encoding should be UTF-8.
 
        createdb -E UTF8 -T template0 --lc-collate=ja_JP.UTF-8 --lc-ctype=ja_JP.UTF-8 testdb
 
   2) Pre-compile the sample programs
 
-       cd <your install path>/ocesql-1.3.0/sample
+       cd <your install path>/Open-COBOL-ESQL/sample
        ocesql INSERTTBL.cbl INSERTTBL.cob
        ocesql FETCHTBL.cbl FETCHTBL.cob
 
@@ -133,14 +144,14 @@ To run the sample programs:
 
      Working with Micro Focus Server Express or Visual COBOL:
 
-       export COBCPY=<your install path>/ocesql-1.3.0/copy
+       export COBCPY=<your install path>/Open-COBOL-ESQL/copy
        cob -ze "" /usr/local/lib/libocesql.so -o mfocesql.so
        cob -x INSERTTBL.cob -C"INITCALL(mfocesql)"
        cob -x FETCHTBL.cob -C"INITCALL(mfocesql)"
 
      Working with OpenCOBOL or opensource COBOL:
 
-       export COBCPY=<your install path>/ocesql-1.3.0/copy
+       export COBCPY=<your install path>/Open-COBOL-ESQL/copy
        cobc -x -locesql INSERTTBL.cob
        cobc -x -locesql FETCHTBL.cob
 
@@ -150,6 +161,7 @@ To run the sample programs:
        ./FETCHTBL
 
    * To create a sample table, run INSERTTBL first.
+     Database credentials are hardcoded in each sample program and by default access is as the "postgres" user.
 
 7. Working with PostgreSQL
 ==========================


### PR DESCRIPTION
Move the "install with PostgreSQL >= 9.0" notes above the "PostgreSQL < 9.0" ones. Fix some minor typos / historical artifacts, such as the default directory here on Guthub being "Open-COBOL-ESQL". Made the "English or Japanese" clearer in the "createdb" etc. Noted that DB credentials are hardcoded, since errors from that are not self-explanatory.

Addresses https://github.com/opensourcecobol/Open-COBOL-ESQL/issues/86 .