### PR TITLE
allow periods in filenames with SQL INCLUDE

### DIFF
--- a/ocesql/scanner.l
+++ b/ocesql/scanner.l
@@ -75,7 +75,6 @@ yyinput (char *buf, int max_size);
 JPNWORD [\xA0-\xDF]|([\x81-\x9F\xE0-\xFC][\x40-\x7E\x80-\xFC])
 DIGIT [0-9]
 WORD ([A-Za-z\+\-0-9_]|[(]|[)]|[\'])
-INCFILE [A-Za-z0-9_\+\-]+
 FILENAME [A-Za-z0-9_\+\-\.]+
 STRVALUE ("\""[^\"]*"\""|"\'"[^\']*"\'")
 HEXVALUE "X"("\""[^\"]+"\""|"\'"[^\']+"\'")
@@ -514,7 +513,7 @@ INT_CONSTANT {digit}+
 		yy_pop_state();
 		return END_EXEC;
 	}
-	{INCFILE} {
+	{FILENAME} {
 		memset(commandname,0,sizeof(commandname));
 		com_strcpy(commandname,sizeof(commandname),"INCFILE");
 		yylval.s = com_strdup (yytext);


### PR DESCRIPTION
it likely would be a good idea to:
* also allow quotes
* possibly always upper-case if no quotes are used
* possibly add an extension list - that is likely reasonable to implement with #90

fair warning: this is not tested, I was only seeing the famous "syntax error" message and found it to be rooted in the period (and before in the quotes used)