### PR TITLE
ocesql.c:: fix double call to add_cursor_list_with_prepare

### DIFF
--- a/dblib/ocesql.c
+++ b/dblib/ocesql.c
@@ -1204,9 +1204,10 @@ _ocesqlPreparedCursorDeclare(struct sqlca_t *st, int id, char *cname, char *snam
 		return;
 	}
 
-	if((res = add_cursor_list_with_prepare(id, cname, prepare)) == RESULT_FAILED){
+	res = add_cursor_list_with_prepare(id, cname, prepare);
+	if(res == RESULT_FAILED){
 		OCDBSetLibErrorStatus(st,OCDB_WARNING_PORTAL_EXISTS);
-	}else if((res = add_cursor_list_with_prepare(id, cname, prepare)) == RESULT_ERROR){
+	}else if(res == RESULT_ERROR){
 		OCDBSetLibErrorStatus(st,OCDB_OUT_OF_MEMORY);
 	}
 }


### PR DESCRIPTION
which create a wrong log message on each PREPARE and had some minor performance impact (at least with a lot of active programs that have prepared statements)