### PR TITLE
test improvementes (makefile)

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,19 +1,53 @@
-MODULES=basic cobol_data sql_data sqlca misc
+top_srcdir ?= ..
+srcdir = $(top_srcdir)/tests
+top_builddir ?= ..
+builddir = $(top_builddir)/tests
 
-.PHONY: clean all help
+MODULES_RUN=basic_run cobol_data_run sql_data_run sqlca_run misc_run
+MODULES=$(srcdir)/basic $(srcdir)/cobol_data $(srcdir)/sql_data $(srcdir)/sqlca $(srcdir)/misc
+LOCAL_HELPERS=atlocal embed_db_info.sh cobol_runner.sh
+
+.PHONY: clean distclean all help $(MODULES_RUN) check
 
 all: $(MODULES)
-
-clean:
-	rm -f $(MODULES)
 
 help:
 	@cat README
 
+clean:
+	rm -rf *.dir *.log
+
+distclean: clean
+	rm -f $(MODULES)
+
+check: $(MODULES) atlocal embed_db_info.sh cobol_runner.sh
+	make -f $(srcdir)/Makefile -k $(MODULES_RUN)
+	cat *.log
+	[ -z "$(cat *.log | grep 'Failed tests:')" ]
+
+$(LOCAL_HELPERS):
+	if test -f $@; then \
+		touch $@ ; \
+	else \
+		cp -p $(top_srcdir)/.github/workflows/ubuntu-test-settings/$@ . ; \
+	fi
+
 .SUFFIXES: .at
+
+basic_run: $(srcdir)/basic
+	$(srcdir)/basic
+cobol_data_run: $(srcdir)/cobol_data
+	$(srcdir)/cobol_data
+sql_data_run: $(srcdir)/sql_data
+	$(srcdir)/sql_data
+sqlca_run: $(srcdir)/sqlca
+	$(srcdir)/sqlca
+misc_run: $(srcdir)/misc
+	$(srcdir)/misc
 
 #.at: package.m4 atlocal.in
 .at: package.m4
+	cd $(srcdir)
 	autom4te --language=autotest -I $@.src -o $@ $@.at
 	chmod +x $@
 


### PR DESCRIPTION
* target `clean` only removes testsuite results
* new target `distcheck` deleting also autoconf generated scripts
* new target `check` 
  * ensure helpers are available
  * clean old results
  * run tests
  * present the logs and fail on failed tests
  * clean old results
* partial support for out-of-tree builds (need to manually specify top_srcdir)