### PR TITLE
c89 compat for preprocessor

### DIFF
--- a/ocesql/ocesql.h
+++ b/ocesql/ocesql.h
@@ -141,12 +141,12 @@ struct cb_field {
 	char	*sname;
 	int		level;
 	int		usage;
-//	int		sign_leading;
+	/* int		sign_leading; */
 	int		occurs;
 	struct cb_field *parent;
 	struct cb_field *children;
 	struct cb_field *sister;
-//	char  *picname;
+	/* char  *picname; */
 
 	int pictype;
 	int picnsize;

--- a/ocesql/parser.y
+++ b/ocesql/parser.y
@@ -350,7 +350,7 @@ sqlvariantstates: WORKINGBEGIN {
 
 sqlvariantstate_list
 WORKINGEND {
-	// check host_variable
+	/* check host_variable */
 	put_exec_list();
 }
 ;
@@ -383,7 +383,7 @@ data_description_clause_sequence
 |NUMERIC {
 	struct cb_field *x;
 
-	x =  cb_build_field_tree( $1, "" , current_field); // regist dummy name
+	x =  cb_build_field_tree( $1, "" , current_field); /* regist dummy name */
 	if( x != NULL){
 		if( x->level != 78)
 			current_field = x;
@@ -640,7 +640,8 @@ int gethostvarianttype(char *name,  int *type, int *digits, int *scale)
 		}
 		*type = tmp_type;
 		return 0;
-	} else { // Group data
+	} else {
+		/* Group data */
 		if(p->occurs > 0){
 			struct cb_field * c;
 

--- a/ocesql/scanner.l
+++ b/ocesql/scanner.l
@@ -714,8 +714,7 @@ INT_CONSTANT {digit}+
 
 
 <*>[ \t]+ {
-
-	//Ignore
+	/* Ignore */
 }
 
 . {}


### PR DESCRIPTION
* changed to move declaration only on new scope
* changed to c89 comment style

can be tested with
` make CC="gcc -std=c89" CPPFLAGS="-Werror=declaration-after-statement`

Note: ocesql.c done in #99
