### PR TITLE
Fix access violation on Windows

### DIFF
--- a/dblib/ocpgsql.c
+++ b/dblib/ocpgsql.c
@@ -544,8 +544,8 @@ OCDB_PGSetResultStatus(unsigned long connaddr, struct sqlca_t *st){
 }
 
 int
-OCDB_PGSetLibErrorStatus(struct sqlca_t *st, int errno){
-	switch(errno){
+OCDB_PGSetLibErrorStatus(struct sqlca_t *st, int errorno){
+	switch(errorno){
 	case OCDB_NO_ERROR:
 		st->sqlcode = OCPG_NO_ERROR;
 		SET_SQLSTATE(st->sqlstate,"00000");


### PR DESCRIPTION
I'm trying to use OCESQL on Windows. I wrote a simple program that does nothing but connecting to the database. While I run, I got an access violation in function `OCDB_PGSetLibErrorStatus`:
![2](https://github.com/opensourcecobol/Open-COBOL-ESQL/assets/22293202/98025fad-c1e9-42e8-9403-96d8f7191078)
The program runs into a address very weird:
![3](https://github.com/opensourcecobol/Open-COBOL-ESQL/assets/22293202/fef44866-d8e2-4a4d-976a-c3f0ee3a8c85)
![4](https://github.com/opensourcecobol/Open-COBOL-ESQL/assets/22293202/888e7953-9a27-402a-ab93-9bee51d5f813)
Both the "Call Stack" window and the disassembly shows the program has entered another function , but 
I checked the C code of `OCDB_PGSetLibErrorStatus`, I cannot find any function-calling at the switch statement.
![5](https://github.com/opensourcecobol/Open-COBOL-ESQL/assets/22293202/ce0bb6d1-bc13-428e-94d1-f2fcc00862bb)
I found the issue is caused by parameter name `errno`.  `errno` is a marco defined in errno.h.
![6](https://github.com/opensourcecobol/Open-COBOL-ESQL/assets/22293202/b58066f8-2664-4103-af16-d355c7473ee1)
So after C preprocessing, the code:
```c
int
OCDB_PGSetLibErrorStatus(struct sqlca_t *st, int errno){
	switch(errno){
// ....
```
Actually becomes:
```c
int
OCDB_PGSetLibErrorStatus(struct sqlca_t *st, int *(*_errno)()){
	switch(*_errno()){
// ....
```
![1](https://github.com/opensourcecobol/Open-COBOL-ESQL/assets/22293202/8338261d-315d-496c-baca-e40a1a396685)
Emm..........
After renaming parameter `errno` to `errorno`, the problem gone.