### PR TITLE
huge speedup for executing SQL with lots of bind variables

### DIFF
--- a/dblib/ChangeLog
+++ b/dblib/ChangeLog
@@ -1,10 +1,18 @@
 
+2024-04-24  Simon Sobisch <simonsobisch@gnu.org>
+
+	* ocesql.c (init_sql_var_list, reset_sql_var_list, add_sql_var_list,
+	  add_sql_res_var_list): remove the need to iterate over the complete
+	  SQLVARLIST of _sql_var_lists and _sql_res_var_lists by saving the
+	  pointer of the last entry, leading to huge speedup for executing
+	  SQL with lots of bind variables (nearly all time for binding was
+	  spent here before)
+
 2023-01-07  Simon Sobisch <simonsobisch@gnu.org>
 
 	* Makefile.am: use BUILT_SOURCES to ensure bison/flex generated
 	  sources are built first (and distributed and only deleted on
 	  make maintainer-clean)
-
 
 2022-02-02  Simon Sobisch <simonsobisch@gnu.org>
 

--- a/dblib/ChangeLog
+++ b/dblib/ChangeLog
@@ -7,6 +7,8 @@
 	  pointer of the last entry, leading to huge speedup for executing
 	  SQL with lots of bind variables (nearly all time for binding was
 	  spent here before)
+    * ocesql.c (new_sql_var_list): use pool of sql variables instead of
+	  recreating them each time (memset instead of free + malloc)
 
 2023-01-07  Simon Sobisch <simonsobisch@gnu.org>
 

--- a/dblib/ChangeLog
+++ b/dblib/ChangeLog
@@ -1,4 +1,9 @@
 
+2024-04-26  Simon Sobisch <simonsobisch@gnu.org>
+
+	* ocesql.c (create_coboldata): prefer local buffers over temporary mallocs;
+	  only space-pad PIC X/PIC N instead of space-fill then overwrite
+
 2024-04-24  Simon Sobisch <simonsobisch@gnu.org>
 
 	* ocesql.c (init_sql_var_list, reset_sql_var_list, add_sql_var_list,
@@ -37,11 +42,16 @@
 	  to current working directory instead of D:\develop
 	* ocdbutil.c (com_sleep, com_strdup): inlined calculation
 
+2022-01-13  Simon Sobisch <simonsobisch@gnu.org>
+
+	* ocesql.c (create_coboldata): fixed buffer-overflows with COMP-3
+	  and signed DISPLAY
+
 2021-07-05  Simon Sobisch <simonsobisch@gnu.org>
 
 	* Makefile.am: added EXTRA_DIST to ship headers, necessary for make dist
 
-Copyright 2021 Simon Sobisch
+Copyright 2021,2022,2024 Simon Sobisch
 
 Copying and distribution of this file, with or without modification, are
 permitted provided the copyright notice and this notice are preserved.

--- a/dblib/ocesql.c
+++ b/dblib/ocesql.c
@@ -26,6 +26,8 @@
 #include "ocdbutil.h"
 #include "ocesql.h"
 
+#define MAX_DIGITS 38
+
 typedef struct sql_var {
 	int type; // set OCDB_TYPE_*
 	int length; // size
@@ -2767,12 +2769,7 @@ create_coboldata(SQLVAR *sv, int index, char *retstr){
 
 		int fillzero;
 		int zcount;
-		char *final;
-		int finalbuflen;
-
-		// fill zero
-		finalbuflen = sv->length + TERMINAL_LENGTH;
-		final = (char *)calloc(finalbuflen, sizeof(char));
+		char final[MAX_DIGITS + 1 + TERMINAL_LENGTH] = { 0 };
 
 		// before decimal point
 		int beforedp = 0;
@@ -2813,7 +2810,6 @@ create_coboldata(SQLVAR *sv, int index, char *retstr){
 		}
 
 		memcpy(addr, final, sv->length);
-		free(final);
 		break;
 	}
 	case OCDB_TYPE_SIGNED_NUMBER_TC:
@@ -2824,13 +2820,8 @@ create_coboldata(SQLVAR *sv, int index, char *retstr){
 
 		int fillzero;
 		int zcount;
-		char *final;
-		int finalbuflen;
+		char final[MAX_DIGITS + SIGN_LENGTH + 1 + TERMINAL_LENGTH] = {0};
 		int final_length;
-
-		// fill zero
-		finalbuflen = sv->length;
-		final = (char *)calloc(finalbuflen, sizeof(char));
 
 		if(retstr[0] == '-'){
 			is_negative = true;
@@ -2883,7 +2874,6 @@ create_coboldata(SQLVAR *sv, int index, char *retstr){
 		}
 
 		memcpy(addr, final, sv->length);
-		free(final);
 		break;
 	}
 	case OCDB_TYPE_SIGNED_NUMBER_LS:
@@ -2893,12 +2883,7 @@ create_coboldata(SQLVAR *sv, int index, char *retstr){
 
 		int fillzero;
 		int zcount;
-		char *final;
-		int finalbuflen;
-
-		// fill zero
-		finalbuflen = SIGN_LENGTH +  sv->length + TERMINAL_LENGTH;
-		final = (char *)calloc(finalbuflen, sizeof(char));
+		char final[MAX_DIGITS + SIGN_LENGTH + 1 + TERMINAL_LENGTH] = {0};
 
 		if(retstr[0] == '-'){
 			final[0] = '-';
@@ -2947,7 +2932,6 @@ create_coboldata(SQLVAR *sv, int index, char *retstr){
 		}
 
 		memcpy(addr, final, sv->length + SIGN_LENGTH);
-		free(final);
 		break;
 	}
 	case OCDB_TYPE_UNSIGNED_NUMBER_PD:
@@ -2958,9 +2942,9 @@ create_coboldata(SQLVAR *sv, int index, char *retstr){
 
 		int fillzero;
 		int zcount;
-		char *pre_final;
-		int pre_final_len;
-		char *final;
+
+		char pre_final[MAX_DIGITS];
+		char final[(MAX_DIGITS + 1) / 2];
 
 		int i;
 		unsigned char ubit = 0xF0;
@@ -2968,9 +2952,6 @@ create_coboldata(SQLVAR *sv, int index, char *retstr){
 
 		const int dlength = (sv->length / 2) + 1;
 		const int skip_first = (sv->length + 1) % 2; // 1 -> skip first 4 bits
-
-		pre_final_len = sv->length + TERMINAL_LENGTH;
-		pre_final = (char *)calloc(pre_final_len, sizeof(char));
 
 		// before decimal point
 		int beforedp = 0;
@@ -3010,7 +2991,6 @@ create_coboldata(SQLVAR *sv, int index, char *retstr){
 		}
 
 		// format setting
-		final = (char *)calloc((int)dlength + TERMINAL_LENGTH, sizeof(char));
 		ptr = pre_final;
 		for(i=0; i<dlength; i++){
 			unsigned char vubit = 0x00;
@@ -3035,9 +3015,7 @@ create_coboldata(SQLVAR *sv, int index, char *retstr){
 			final[i] = vubit | vlbit;
 		}
 
-		memcpy(addr, final, (int)dlength);
-		free(pre_final);
-		free(final);
+		memcpy(addr, final, dlength);
 		break;
 	}
 	case OCDB_TYPE_SIGNED_NUMBER_PD:
@@ -3048,9 +3026,9 @@ create_coboldata(SQLVAR *sv, int index, char *retstr){
 
 		int fillzero;
 		int zcount;
-		char *pre_final;
-		int pre_final_len;
-		char *final;
+
+		char pre_final [MAX_DIGITS];
+		char final[(MAX_DIGITS + 1) / 2];
 
 		int i;
 		unsigned char ubit = 0xF0;
@@ -3065,9 +3043,6 @@ create_coboldata(SQLVAR *sv, int index, char *retstr){
 		} else {
 			value = retstr;
 		}
-
-		pre_final_len = (int)dlength + TERMINAL_LENGTH;
-		pre_final = (char *)calloc(pre_final_len, sizeof(char));
 
 		// before decimal point
 		int beforedp = 0;
@@ -3107,7 +3082,6 @@ create_coboldata(SQLVAR *sv, int index, char *retstr){
 		}
 
 		// format setting
-		final = (char *)calloc((int)dlength + TERMINAL_LENGTH, sizeof(char));
 		ptr = pre_final;
 		for(i=0; i<dlength; i++){
 			unsigned char vubit = 0x00;
@@ -3136,65 +3110,75 @@ create_coboldata(SQLVAR *sv, int index, char *retstr){
 			final[i] = vubit | vlbit;
 		}
 
-		memcpy(addr, final, (int)dlength);
-		free(pre_final);
-		free(final);
+		memcpy(addr, final, dlength);
 		break;
 	}
-	case OCDB_TYPE_ALPHANUMERIC:
+	case OCDB_TYPE_ALPHANUMERIC: {
 		// 文字の長さだけメモリコピー
-		if(strlen(retstr) >= sv->length){
+		const size_t rlen = strlen(retstr);
+		if(rlen >= sv->length){
 			memcpy(addr, retstr, sv->length);
 		}else{
-			memset(addr,' ',sv->length);
-			memcpy(addr,retstr,strlen(retstr));
+			memcpy(addr,retstr,rlen);
+			memset(addr + rlen,' ',sv->length - rlen);
 		}
 		break;
-	case OCDB_TYPE_JAPANESE:
+	}
+	case OCDB_TYPE_JAPANESE: {
 		// 文字の長さだけメモリコピー
-		if(strlen(retstr) >= sv->length*2){
-			memcpy(addr, retstr, sv->length*2);
+		const size_t memlen = sv->length*2;
+		const size_t rlen = strlen(retstr);
+		if(rlen >= memlen){
+			memcpy(addr, retstr, memlen);
 		}else{
-			int i;
-			char *tmp = (char *)addr;
-			for(i=0;i+1<sv->length*2;i=i+2){
+			size_t i;
+			char *tmp;
+			memcpy(addr,retstr,rlen);
+			tmp = (char *)addr + rlen;
+			for(i=0;i+1<(memlen - rlen);i=i+2){
 				tmp[i] = 0x81;
 				tmp[i+1] = 0x40;
 			}
-			memcpy(addr,retstr,strlen(retstr));
 		}
 		break;
-	case OCDB_TYPE_ALPHANUMERIC_VARYING:
-		if(strlen(retstr) >= sv->length){
+	}
+	case OCDB_TYPE_ALPHANUMERIC_VARYING: {
+		const size_t rlen = strlen(retstr);
+		if(rlen >= sv->length){
 			tmp_len = sv->length;
 			memcpy(addr, &tmp_len, OCDB_VARCHAR_HEADER_BYTE);
 			memcpy((char *)addr + OCDB_VARCHAR_HEADER_BYTE, retstr, sv->length);
 		} else {
-			tmp_len = strlen(retstr);
+			tmp_len = rlen;
 			memcpy(addr, &tmp_len, OCDB_VARCHAR_HEADER_BYTE);
-			memset((char *)addr + OCDB_VARCHAR_HEADER_BYTE,' ',sv->length);
-			memcpy((char *)addr + OCDB_VARCHAR_HEADER_BYTE,retstr,strlen(retstr));
+			memcpy((char *)addr + OCDB_VARCHAR_HEADER_BYTE,retstr,rlen);
+			memset((char *)addr + OCDB_VARCHAR_HEADER_BYTE + rlen,' ',sv->length - rlen);
 		}
 		LOG("VARYING-LEN:%d\n",tmp_len);
 		break;
-	case OCDB_TYPE_JAPANESE_VARYING:
-		if(strlen(retstr) >= sv->length*2){
+	}
+	case OCDB_TYPE_JAPANESE_VARYING: {
+		const size_t memlen = sv->length*2;
+		const size_t rlen = strlen(retstr);
+		if(rlen >= memlen){
 			tmp_len = sv->length;
 			memcpy(addr, &tmp_len, OCDB_VARCHAR_HEADER_BYTE);
-			memcpy(addr, retstr, sv->length*2);
-		}else{
+			memcpy(addr, retstr, memlen);
+		} else {
 			int i;
-			char *tmp = (char *)((char *)addr+OCDB_VARCHAR_HEADER_BYTE);
-			for(i=0;i+1<sv->length*2;i=i+2){
+			char *tmp;
+			tmp_len = rlen/2;
+			memcpy(addr, &tmp_len, OCDB_VARCHAR_HEADER_BYTE);
+			memcpy((char *)addr + OCDB_VARCHAR_HEADER_BYTE + rlen,retstr,rlen);
+			tmp = (char *)((char *)addr+OCDB_VARCHAR_HEADER_BYTE+rlen);
+			for(i=0;i+1<(memlen-rlen);i=i+2){
 				tmp[i] = 0x81;
 				tmp[i+1] = 0x40;
 			}
-			tmp_len = strlen(retstr)/2;
-			memcpy(addr, &tmp_len, OCDB_VARCHAR_HEADER_BYTE);
-			memcpy((char *)addr + OCDB_VARCHAR_HEADER_BYTE,retstr,tmp_len*2);
 		}
 		LOG("VARYING-LEN:%d\n",tmp_len);
 		break;
+	}
 	default:
 		break;
 	}

--- a/dblib/ocesql.c
+++ b/dblib/ocesql.c
@@ -71,12 +71,12 @@ static SQLVARLIST *_sql_var_lists = NULL;
 static SQLVARLIST *_sql_var_lists_last = NULL;
 static SQLVARLIST *_sql_res_var_lists = NULL;
 static SQLVARLIST *_sql_res_var_lists_last = NULL;
+static SQLVARLIST *_pool_sql_var_list = NULL; // Pool of SQLVARLIST items
 static int _var_lists_length = 0;
 static int _res_var_lists_length = 0;
 static int _occurs_length = 0;
 static int _occurs_iter = 0;
 static int _occurs_is_parent = 0;
-
 
 static void sqlca_initialize(struct sqlca_t *);
 
@@ -2366,9 +2366,17 @@ reset_sql_var_list(void){
  * <Outline>
  *   埋め込みSQLリスト生成
  */
-static inline SQLVARLIST *
-new_sql_var_list(void){
-	return (SQLVARLIST *)calloc(1, sizeof(SQLVARLIST));
+
+static inline SQLVARLIST *new_sql_var_list(void) {
+	SQLVARLIST *new_item;
+	if (_pool_sql_var_list != NULL) {
+		new_item = _pool_sql_var_list;
+		_pool_sql_var_list = _pool_sql_var_list->next;
+		new_item->next = NULL; // Initialize the item
+	} else {
+		new_item = (SQLVARLIST *)calloc(1, sizeof(SQLVARLIST));
+	}
+	return new_item;
 }
 
 /*
@@ -3286,17 +3294,38 @@ static void show_sql_var_list(SQLVARLIST *p){
  * <Input>
  *   @SQLVARLIST *
  */
-static void
-clear_sql_var_list(SQLVARLIST *p){
-	if(p != NULL){
-		clear_sql_var_list(p->next);
-		if(p->sv.data)
-			free(p->sv.data);
-		if(p->sv.realdata)
-			free(p->sv.realdata);
-		free(p);
+static void clear_sql_var_list(SQLVARLIST *p) {
+	if (p == NULL)
+		return; // Nothing to clear
+
+	SQLVARLIST *temp = p;
+	SQLVARLIST *last_item = NULL;
+	while (temp != NULL) {
+		SQLVARLIST *next = temp->next;
+		if (temp->sv.data)
+			free(temp->sv.data);
+		if (temp->sv.realdata)
+			free(temp->sv.realdata);
+		// Initialize the item before returning it to the pool
+		memset(&temp->sv, 0, sizeof(SQLVAR));
+		last_item = temp;
+		temp = next;
+	}
+	// Return the entire list to the pool
+	last_item->next = _pool_sql_var_list;
+	_pool_sql_var_list = p;
+}
+
+#if 0
+/* free memory, this shoulkd be called at program exit, currently unused */
+static void cleanup_sql_var_pool(void) {
+	while (_pool_sql_var_list != NULL) {
+		SQLVARLIST *next = _pool_sql_var_list->next;
+		free(_pool_sql_var_list);
+		_pool_sql_var_list = next;
 	}
 }
+#endif
 
 static void
 _ocesqlReleaseConnection(int status, void *arg){

--- a/dblib/ocesql.c
+++ b/dblib/ocesql.c
@@ -1,6 +1,6 @@
-﻿/*
+/*
  * Copyright (C) 2015, 2022 Tokyo System House Co.,Ltd.
- * Copyright (C) 2022, 2023 Simon Sobisch
+ * Copyright (C) 2022-2024 Simon Sobisch
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -68,7 +68,9 @@ typedef struct cursor_list {
 static PREPARELIST _prepare_list = {{NULL, NULL, 0}, NULL};
 static CURSORLIST _cursor_list = {0, NULL, NULL, NULL, 0, 0, 0, NULL, NULL};
 static SQLVARLIST *_sql_var_lists = NULL;
+static SQLVARLIST *_sql_var_lists_last = NULL;
 static SQLVARLIST *_sql_res_var_lists = NULL;
+static SQLVARLIST *_sql_res_var_lists_last = NULL;
 static int _var_lists_length = 0;
 static int _res_var_lists_length = 0;
 static int _occurs_length = 0;
@@ -2321,15 +2323,17 @@ init_sql_var_list(void){
 	}
 	reset_sql_var_list();
 
-	if((_sql_var_lists = new_sql_var_list()) == NULL){
+	if((_sql_var_lists_last = new_sql_var_list()) == NULL){
 		ERRLOG("cannot initialize SQLVARLIST\n");
 		return;
 	}
+	_sql_var_lists = _sql_var_lists_last;
 
-	if((_sql_res_var_lists = new_sql_var_list()) == NULL){
+	if((_sql_res_var_lists_last = new_sql_var_list()) == NULL){
 		ERRLOG("cannot initialize SQLVARLIST\n");
 		return;
 	}
+	_sql_res_var_lists = _sql_res_var_lists_last;
 
 	return;
 }
@@ -2345,8 +2349,8 @@ init_sql_var_list(void){
  */
 static void
 reset_sql_var_list(void){
-	_sql_var_lists = NULL;
-	_sql_res_var_lists = NULL;
+	_sql_var_lists = _sql_var_lists_last = NULL;
+	_sql_res_var_lists = _sql_res_var_lists_last = NULL;
 	_var_lists_length = 0;
 	_res_var_lists_length = 0;
 	_occurs_length = 0;
@@ -2387,18 +2391,14 @@ new_sql_var_list(void){
 static SQLVARLIST *
 add_sql_var_list(int type , int length, int power, void *addr){
 
-	SQLVARLIST *p = _sql_var_lists;
+	SQLVARLIST *p = _sql_var_lists_last;
 
-	if(_sql_var_lists == NULL){
-		ERRLOG("_sql_var_lists has not been initialized\n");
+	if(_sql_var_lists_last == NULL){
+		ERRLOG("_sql_var_lists_last has not been initialized\n");
 		return NULL;
 	}
 
-	while(p->next != NULL){
-		p = p->next;
-	}
-
-	if((p->next = new_sql_var_list()) == NULL){
+	if((_sql_var_lists_last = new_sql_var_list()) == NULL){
 		ERRLOG("cannot generate new SQLVARLIST\n");
 		return NULL;
 	}
@@ -2407,7 +2407,7 @@ add_sql_var_list(int type , int length, int power, void *addr){
 	p->sv.length = length;
 	p->sv.power = power;
 	p->sv.addr = addr;
-
+	p->next = _sql_var_lists_last;
 
 	create_realdata(&p->sv, 0);
 	_var_lists_length++;
@@ -2434,18 +2434,14 @@ add_sql_var_list(int type , int length, int power, void *addr){
  */
 static SQLVARLIST *
 add_sql_res_var_list(int type , int length, int power, void *addr){
-	SQLVARLIST *p = _sql_res_var_lists;
+	SQLVARLIST *p = _sql_res_var_lists_last;
 
-	if(_sql_res_var_lists == NULL){
-		ERRLOG("_sql_var_lists has not been initialized\n");
+	if(_sql_res_var_lists_last == NULL){
+		ERRLOG("_sql_res_var_lists_last has not been initialized\n");
 		return NULL;
 	}
 
-	while(p->next != NULL){
-		p = p->next;
-	}
-
-	if((p->next = new_sql_var_list()) == NULL){
+	if((_sql_res_var_lists_last = new_sql_var_list()) == NULL){
 		ERRLOG("cannot generate new SQLVARLIST\n");
 		return NULL;
 	}
@@ -2454,6 +2450,7 @@ add_sql_res_var_list(int type , int length, int power, void *addr){
 	p->sv.length = length;
 	p->sv.power = power;
 	p->sv.addr = addr;
+	p->next = _sql_res_var_lists_last;
 
 	_res_var_lists_length++;
 


### PR DESCRIPTION
dblib/ocesql.c (init_sql_var_list, reset_sql_var_list, add_sql_var_list, add_sql_res_var_list): remove the need to iterate over the complete SQLVARLIST of _sql_var_lists and _sql_res_var_lists by saving the pointer of the last entry, fixes #84

before this change a relative simple COBOL program creating a report from ~5000 DB reads had 60% of its cpu-cost in libocesql (mostly in the `add_sql_res_var_list()` function), while libpg had 6% (checked with `perf record`).

After this change liboceql is down to 12% and libpg using 16%

Setting to a draft for possible more performance-related follow-up changes.