### PR TITLE
Fix error when using VARYING to PREPARE and return code on error

### DIFF
--- a/ocesql/errorfile.c
+++ b/ocesql/errorfile.c
@@ -37,6 +37,7 @@ static char errormsg[ERRORMSGNUM][128] = {
 	{"E999: unexpected error"}
 };
 static FILE *pfile;
+int errmsgflg;
 
 int openerrorfile(char *filename){
 	if( filename != NULL){
@@ -102,6 +103,8 @@ int printerrormsg(char *name, int line, char * code){
 	char buff[MAXBUFFSIZE];
 	int ilen ;
 	char *p;
+
+	errmsgflg = 1;
 
 	if( code == NULL || line <=0 || name == NULL)
 		return 0;

--- a/ocesql/ocesql.c
+++ b/ocesql/ocesql.c
@@ -95,6 +95,7 @@ int translate (struct filename *fn)
 	int ret;
 	char *tmpfile;
 
+	errmsgflg = 0;
 	tmpfile = gettmpname("tmp");
 
 	/* 1st: LOAD INCLUDE FILE */
@@ -129,6 +130,10 @@ int translate (struct filename *fn)
 	}
 
 	ppoutput(tmpfile, fn->translate, exec_list);
+
+	if(errmsgflg == 1){
+		return -1;
+	}
 
 	return 0;
 }

--- a/ocesql/ocesql.h
+++ b/ocesql/ocesql.h
@@ -182,6 +182,7 @@ extern int EOFflg;
 extern int EOFFLG;
 extern int pointflg;
 extern int lineNUM;
+extern int errmsgflg;
 
 extern int yylineno;
 extern int startlineno;

--- a/ocesql/ppout.c
+++ b/ocesql/ppout.c
@@ -1027,7 +1027,7 @@ void ppoutputprepare(struct cb_exec_list *list){
 		com_sprintf(buff,sizeof(buff), "E%03d",iret);
 		printerrormsg(list->host_list->hostreference, list->host_list->lineno, buff);
 		return;
-	} else if(l != HVARTYPE_GROUP){
+	} else if(l != HVARTYPE_GROUP && l != HVARTYPE_ALPHANUMERIC_VARYING && l != HVARTYPE_JAPANESE_VARYING){
 		memset(buff, 0, sizeof(buff));
 		com_sprintf(buff,sizeof(buff), "E%03d",ERR_PREPARE_ISNT_GROUP);
 		printerrormsg(list->host_list->hostreference, list->host_list->lineno, buff);


### PR DESCRIPTION
When using a variable with VARYING in a PREPARE statement, the error message "E013: variable for PREPARE should be GROUP."
Fixed so that this message does not appear.

When an error message related to an SQL statement was generated, the return code would exit with 0.
Fixed so that the return code is -1.