### PR TITLE
Fix position of period when using "CLOSE"

### DIFF
--- a/ocesql/ppout.c
+++ b/ocesql/ppout.c
@@ -1933,14 +1933,8 @@ void ppbuff(struct cb_exec_list *list){
 		outwrite();
 
 		com_strcpy(out,sizeof(out),"OCESQL ");
-
-		com_strcat(out, sizeof(out), "   ");
-		com_strcat(out, sizeof(out), strend);
-
-		outwrite();
-
-		com_strcpy(out,sizeof(out),"OCESQL ");
 		com_strcat(out,sizeof(out),"   ");
+		com_strcat(out, sizeof(out), strend);
 		if( l->period)
 			com_strcat(out,sizeof(out),".");
 		outwrite();


### PR DESCRIPTION
Fix position of period when using "CLOSE".

```
CALL "OCESQLCursorClose"  USING
     BY REFERENCE SQLCA
     BY REFERENCE "close_period_C1" & x"00"
END-CALL
.
```
↓
```
CALL "OCESQLCursorClose"  USING
     BY REFERENCE SQLCA
     BY REFERENCE "close_period_C1" & x"00"
END-CALL.
```
