### PR TITLE
Fix error about last line of generated COBOL files.

### DIFF
--- a/ocesql/ppout.c
+++ b/ocesql/ppout.c
@@ -2029,16 +2029,21 @@ void ppoutput(char *ppin,char *ppout,struct cb_exec_list *head){
 
 	EOFFLG = 0;
 	if (readfile && outfile){
-		for(;EOFflg != 1;){
+		while(EOFflg != 1){
 			com_readline(readfile, inbuff, &lineNUM, &EOFflg);
 			if(strstr(inbuff, INC_START_MARK) != NULL ||
 			strstr(inbuff, INC__END__MARK) != NULL){
 				continue;
 			}
+
 			if(head){
 				if (l->startLine<= lineNUM && l->endLine>=lineNUM){
 					if(strcmp(l->commandName,"WORKING_END")==0){
 						ppbuff(l);
+					}
+
+					if(EOFflg == 1){
+						break;
 					}
 
 					if(strcmp(l->commandName,"WORKING_BEGIN")!=0 &&
@@ -2055,7 +2060,6 @@ void ppoutput(char *ppin,char *ppout,struct cb_exec_list *head){
 					outbuff = inbuff;
 					len = strlen(outbuff);
 					fwrite (outbuff ,len, 1 , outfile );
-
 					if (EOFflg == 1){
 						fputc('\n',outfile);
 
@@ -2066,6 +2070,11 @@ void ppoutput(char *ppin,char *ppout,struct cb_exec_list *head){
 						if(strcmp(l->commandName,"WORKING_END")){
 							ppbuff(l);
 						}
+						
+						if(EOFflg == 1){
+							break;
+						}
+
 						if (l->next != NULL)
 							l = l->next;
 
@@ -2084,6 +2093,9 @@ void ppoutput(char *ppin,char *ppout,struct cb_exec_list *head){
 						len = strlen(outbuff);
 						fwrite (outbuff ,len, 1 , outfile );
 					}else{
+						if(EOFflg == 1){
+							break;
+						}
 						outbuff = inbuff;
 						len = strlen(outbuff);
 						fwrite (outbuff ,len, 1 , outfile );
@@ -2091,6 +2103,9 @@ void ppoutput(char *ppin,char *ppout,struct cb_exec_list *head){
 					}
 				}
 			}else{
+				if(EOFflg == 1){
+					break;
+				}
 				outbuff = inbuff;
 				len = strlen(outbuff);
 				fwrite (outbuff ,len, 1 , outfile );
@@ -2116,8 +2131,11 @@ void ppoutput_incfile(char *ppin,char *ppout,struct cb_exec_list *head){
 
 	EOFFLG = 0;
 	if (readfile && outfile){
-		for(;EOFflg != 1;){
+		while(1){
 			com_readline(readfile, inbuff, &lineNUM, &EOFflg);
+			if(EOFflg == 1){
+				break;
+			}
 			if(head){
 				if (l->startLine<= lineNUM && l->endLine>=lineNUM){
 					if (strcmp(l->commandName, "INCFILE") == 0){
@@ -2133,7 +2151,9 @@ void ppoutput_incfile(char *ppin,char *ppout,struct cb_exec_list *head){
 					outbuff = inbuff;
 					len = strlen(outbuff);
 					fwrite (outbuff ,len, 1 , outfile );
-
+					if(strstr(inbuff, "\n") == NULL){
+						fputc('\n',outfile);
+					}
 					if (EOFflg == 1){
 						fputc('\n',outfile);
 					}
@@ -2163,7 +2183,6 @@ void ppoutput_incfile(char *ppin,char *ppout,struct cb_exec_list *head){
 						outbuff = inbuff;
 						len = strlen(outbuff);
 						fwrite (outbuff ,len, 1 , outfile );
-
 					}
 				}
 			}else{


### PR DESCRIPTION
The problem that the code in the last line of a COBOL file is output multiple times after compilation has been corrected.