### PR TITLE
Fix bug of printerrormsg

### DIFF
--- a/ocesql/errorfile.c
+++ b/ocesql/errorfile.c
@@ -104,8 +104,6 @@ int printerrormsg(char *name, int line, char * code){
 	int ilen ;
 	char *p;
 
-	errmsgflg = 1;
-
 	if( code == NULL || line <=0 || name == NULL)
 		return 0;
 	ilen = sizeof(buff);
@@ -123,6 +121,8 @@ int printerrormsg(char *name, int line, char * code){
 
 	fputs(buff, pfile);
 	fputs("\n", pfile);
+
+	errmsgflg = 1;
 
 	return 1;
 }


### PR DESCRIPTION
When printerrormsg() was executed, the specification was that it would unconditionally set errmsgflg to 1 and cause a precompile error.
This is an error. When printerrormsg() is executed, the function basically terminates abnormally, but depending on the conditions, it may terminate normally.
Therefore, it was corrected so that a precompile error is generated only when an abnormal termination occurs.