### PR TITLE
Bug fix for INCLUDE with newlines

### DIFF
--- a/ocesql/scanner.l
+++ b/ocesql/scanner.l
@@ -484,9 +484,15 @@ INT_CONSTANT {digit}+
 	}
 }
 
-"EXEC"[ ]+"SQL"[ ]+"INCLUDE" {
-        period = 0;
-	startlineno = yylineno;
+"EXEC"[ ]+"SQL"[ \r\n]+"INCLUDE" {
+    period = 0;
+	int newlines = 0;
+    for (char *p = yytext; *p != '\0'; p++) {
+        if (*p == '\n') {
+            newlines++;
+        }
+    }
+    startlineno = yylineno - newlines;
 	host_reference_list = NULL;
 	res_host_reference_list = NULL;
 	memset(dbname,0,sizeof(dbname));

--- a/tests/basic.src/include.at
+++ b/tests/basic.src/include.at
@@ -195,3 +195,42 @@ AT_CHECK([ocesql --inc=. prog.cbl prog.cob > /dev/null],[0])
 AT_CHECK([diff prog.cob prog.txt], [0])
 
 AT_CLEANUP
+
+
+AT_SETUP([use include with newline])
+
+AT_DATA([prog.cbl], [
+       IDENTIFICATION              DIVISION.
+      ******************************************************************
+       PROGRAM-ID.                 prog.
+      ******************************************************************
+       DATA                        DIVISION.
+      ******************************************************************
+       WORKING-STORAGE SECTION. 
+       EXEC SQL 
+           INCLUDE SQLCA 
+       END-EXEC.
+       PROCEDURE DIVISION.
+           STOP RUN.
+])
+
+AT_DATA([prog.txt], [
+       IDENTIFICATION              DIVISION.
+      ******************************************************************
+       PROGRAM-ID.                 prog.
+      ******************************************************************
+       DATA                        DIVISION.
+      ******************************************************************
+       WORKING-STORAGE SECTION. 
+OCESQL*EXEC SQL 
+OCESQL*    INCLUDE SQLCA 
+OCESQL*END-EXEC.
+OCESQL     copy "sqlca.cbl".
+       PROCEDURE DIVISION.
+           STOP RUN.
+])
+
+AT_CHECK([ocesql prog.cbl prog.cob > /dev/null],[0])
+AT_CHECK([diff prog.cob prog.txt], [0])
+
+AT_CLEANUP


### PR DESCRIPTION
Fixed an issue where INCLUDE statements spanning multiple lines were not properly handled.
(Related to [Issue#142](https://github.com/opensourcecobol/Open-COBOL-ESQL/issues/142))

**example**
Before conversion:
```COBOL
       WORKING-STORAGE SECTION. 
       EXEC SQL 
           INCLUDE SQLCA 
       END-EXEC.
```

After conversion:
```COBOL
       WORKING-STORAGE SECTION. 
OCESQL*EXEC SQL 
OCESQL*    INCLUDE SQLCA 
OCESQL*END-EXEC.
OCESQL     copy "sqlca.cbl".
```
